### PR TITLE
Add `base` parameter && Use module build type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@sota1235/parse-link-header-ts",
-  "version": "1.0.0",
+  "name": "@renyuneyun/parse-link-header-ts",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sota1235/parse-link-header-ts",
-      "version": "1.0.0",
+      "name": "@renyuneyun/parse-link-header-ts",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@sota1235/eslint-config": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sota1235/parse-link-header-ts",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sota1235/parse-link-header-ts",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@sota1235/eslint-config": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/sota1235/parse-link-header-ts"
   },
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@sota1235/parse-link-header-ts",
-  "version": "1.0.0",
+  "name": "@renyuneyun/parse-link-header-ts",
+  "version": "1.0.1",
   "description": "Parses a link header and returns paging information for each contained link.",
-  "homepage": "https://github.com/sota1235/parse-link-header-ts",
-  "bugs": "https://github.com/sota1235/parse-link-header-ts/issues",
+  "homepage": "https://github.com/renyuneyun/parse-link-header-ts",
+  "bugs": "https://github.com/renyuneyun/parse-link-header-ts/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sota1235/parse-link-header-ts"
+    "url": "https://github.com/renyuneyun/parse-link-header-ts"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ function createObjects(acc: Record<string, string>, p: string) {
   return acc;
 }
 
-function parseLink(link: string): RawLink | null {
+function parseLink(link: string, base?: string): RawLink | null {
   const m = link.match(/<?([^>]*)>(.*)/);
 
   if (m === null) {
@@ -45,7 +45,7 @@ function parseLink(link: string): RawLink | null {
 
   const linkUrl = m[1];
   const parts = m[2].split(';');
-  const parsedUrl = new URL(linkUrl);
+  const parsedUrl = new URL(linkUrl, base);
   const qry: Record<string, string> = {};
 
   for (const [key, value] of parsedUrl.searchParams) {
@@ -68,7 +68,7 @@ function checkHeader(linkHeader: string): void {
   }
 }
 
-export default function (linkHeader: string): Result {
+export default function (linkHeader: string, base?: string): Result {
   if (linkHeader === '') {
     throw new Error('linkHeader is empty');
   }
@@ -77,7 +77,7 @@ export default function (linkHeader: string): Result {
 
   return linkHeader
     .split(/,\s*</)
-    .map(parseLink)
+    .map((link) => parseLink(link, base))
     .filter<Link>(hasRel)
     .reduce(intoRels, {});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNEXT",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "removeComments": true,
     "strict": true,


### PR DESCRIPTION
The `base` parameter is for supporting relative URLs found in the Link header.

Changing the build type to `module` removes the `SyntaxError: ambiguous indirect export: default` error. Though, I'm not JS/TS expert, so am not sure if this is the best way.

Env: I use this library in a Vue project.