### PR TITLE
WIP: Stage npm publish workflow step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Build package
         run: npm run build:publish
 
-      - name: Publishing to npm
-        run: npm publish --provenance --access public
+      - name: Publishing to npm (staged)
+        run: npm stage publish --provenance --access public


### PR DESCRIPTION
## Summary
Updates the npm publish workflow step to use a staged publishing approach instead of direct publication.

## Changes
- Renamed workflow step from "Publishing to npm" to "Publishing to npm (staged)" to clarify the publishing method
- Modified the publish command from `npm publish --provenance --access public` to `npm stage publish --provenance --access public`

## Notes
This appears to be a work-in-progress change to implement staged publishing. The `npm stage publish` command suggests a multi-step release process, though this may require verification that the npm CLI supports this command or that a custom script is configured in `package.json`.

https://claude.ai/code/session_017AuhRQW5HJ3RZAz6bX9cro