### PR TITLE
Exclude Renovate devDependencies updates from changelog

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,15 @@
   ],
   "labels": [
     "kind/dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "addLabels": [
+        "skip-changelog"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Add a packageRule that attaches the skip-changelog label to
devDependencies updates. The changelog is generated from GitHub's
release notes config (.github/release.yml), which excludes PRs
labeled skip-changelog, so devDependency bumps no longer appear.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZtP4ZzeVXQmSLyNvtFXBv